### PR TITLE
renamed some camel cased functions to underscore

### DIFF
--- a/src/TheAlgorithms.jl
+++ b/src/TheAlgorithms.jl
@@ -102,14 +102,14 @@ export jump_search
 export linear_search
 
 # Exports: sorts
-export BubbleSort!
-export BucketSort!
-export CountingSort!
-export ExchangeSort!
-export InsertionSort!
-export MergeSort!
-export QuickSort!
-export SelectionSort!
+export bubble_sort!
+export bucket_sort!
+export counting_sort!
+export exchange_sort!
+export insertion_sort!
+export merge_sort!
+export quick_sort!
+export selection_sort!
 
 # Exports: statistics
 export pearson_correlation
@@ -118,7 +118,7 @@ export variance
 # Exports: strings
 export is_palindrome
 export detect_anagrams
-export ContainSubstringWithKMP
+export contain_substring_with_kmp
 
 # Exports: scheduling
 export fcfs

--- a/src/sorts/bubble_sort.jl
+++ b/src/sorts/bubble_sort.jl
@@ -1,4 +1,4 @@
-function BubbleSort!(arr::Vector{T})where T
+function bubble_sort!(arr::Vector{T})where T
     l=length(arr)-1
     while true
         flag=true

--- a/src/sorts/bucket_sort.jl
+++ b/src/sorts/bucket_sort.jl
@@ -39,7 +39,7 @@ BucketSort!([3, 5, 2, 9]) # returns [2, 3, 5, 9]
 Contributed By:- [Ming Liang](https://github.com/DrakonDarquesse)
 """
 
-function BucketSort!(arr::Vector{T}, l::Int=length(arr)) where T
+function bucket_sort!(arr::Vector{T}, l::Int=length(arr)) where T
     if l==0
         return
     end

--- a/src/sorts/counting_sort.jl
+++ b/src/sorts/counting_sort.jl
@@ -29,7 +29,7 @@ Assume the input as --> x=[-3, 1, -5, 0, -3]
 
 FINAL RESULT -->  [-5, -3, -3, 0, 1]                                                                                    
 """
-function CountingSort!(arr::Vector{T},l::Int=1,r::Int=length(arr))where T
+function counting_sort!(arr::Vector{T},l::Int=1,r::Int=length(arr))where T
     if l>=r
         return
     end

--- a/src/sorts/exchange_sort.jl
+++ b/src/sorts/exchange_sort.jl
@@ -25,7 +25,7 @@ ExchangeSort(['5', '4', '3', '2', '1']) # returns ['1', '2', '3', '4', '5']
 Contributed By:- [Gervin Fung](https://github.com/GervinFung)
 """
 
-function ExchangeSort!(arr::Vector{T})where T
+function exchange_sort!(arr::Vector{T})where T
     size=length(arr)
     for i in 1:size
         for j in i:size

--- a/src/sorts/insertion_sort.jl
+++ b/src/sorts/insertion_sort.jl
@@ -1,4 +1,4 @@
-function InsertionSort!(arr::Vector{T})where T
+function insertion_sort!(arr::Vector{T})where T
     for i in 1:length(arr)-1
         temp=arr[i+1]
         j=i

--- a/src/sorts/merge_sort.jl
+++ b/src/sorts/merge_sort.jl
@@ -1,11 +1,11 @@
-function MergeSort!(arr::Vector{T},l::Int=1,r::Int=length(arr),temp::Vector{T}=Vector{T}(undef,r-l+1))where T
+function merge_sort!(arr::Vector{T},l::Int=1,r::Int=length(arr),temp::Vector{T}=Vector{T}(undef,r-l+1))where T
     if l>=r
         return
     end
     # split
     mid=(l+r)>>1
-    MergeSort!(arr,l,mid)
-    MergeSort!(arr,mid+1,r)
+    merge_sort!(arr,l,mid)
+    merge_sort!(arr,mid+1,r)
     # merge
     l_pos=l # pos of the left part
     r_pos=mid+1 # pos of the right part

--- a/src/sorts/quick_sort.jl
+++ b/src/sorts/quick_sort.jl
@@ -1,4 +1,4 @@
-function QuickSort!(arr::Vector{T},l::Int=1,r::Int=length(arr))where T
+function quick_sort!(arr::Vector{T},l::Int=1,r::Int=length(arr))where T
     if l>=r
         return
     end
@@ -16,6 +16,6 @@ function QuickSort!(arr::Vector{T},l::Int=1,r::Int=length(arr))where T
             r_pos-=1
         end
     end
-    if l<r_pos QuickSort!(arr,l,r_pos) end
-    if l_pos<r QuickSort!(arr,l_pos,r) end
+    if l<r_pos quick_sort!(arr,l,r_pos) end
+    if l_pos<r quick_sort!(arr,l_pos,r) end
 end

--- a/src/sorts/selection_sort.jl
+++ b/src/sorts/selection_sort.jl
@@ -1,4 +1,4 @@
-function SelectionSort!(arr::Vector{T})where T
+function selection_sort!(arr::Vector{T})where T
     l=length(arr)
     for i in 1:l-1
         place=i

--- a/src/strings/kmp_substring_search.jl
+++ b/src/strings/kmp_substring_search.jl
@@ -36,7 +36,7 @@ const NO_SUBSTRING_INDEX = 0
 # Should be convenient for others as most programming language use 0 as first index
 const JULIA_FIRST_INDEX = 1
 
-function CreateSuffixArray(pattern_length::Int, sub_string::String)::Vector{Int}
+function create_suffic_array(pattern_length::Int, sub_string::String)::Vector{Int}
 
     # Longest Proper Prefix which is Suffix array
     lps::Vector{Int} = ones(Int, pattern_length)
@@ -63,7 +63,7 @@ function CreateSuffixArray(pattern_length::Int, sub_string::String)::Vector{Int}
 end
 
 # this function will be used to obtain the index which the substring was found
-function GetIndexWithKMP(string::String, sub_string::String, ignore_case::Bool)::Int
+function get_index_with_kmp(string::String, sub_string::String, ignore_case::Bool)::Int
 
     string = ignore_case ? lowercase(string) : string
     sub_string = ignore_case ? lowercase(sub_string) : sub_string
@@ -71,7 +71,7 @@ function GetIndexWithKMP(string::String, sub_string::String, ignore_case::Bool):
     string_length::Int = length(string)
     substring_length::Int = length(sub_string)
 
-    lps::Vector{Int} = CreateSuffixArray(substring_length, sub_string)
+    lps::Vector{Int} = create_suffic_array(substring_length, sub_string)
 
     # likewise, 1 is the first index, unlike others, where 0 is the first index
     i::Int = JULIA_FIRST_INDEX
@@ -94,6 +94,6 @@ function GetIndexWithKMP(string::String, sub_string::String, ignore_case::Bool):
 end
 
 # optional function that returns boolean if string does contain the sub-string given
-function ContainSubstringWithKMP(string::String, sub_string::String, ignore_case::Bool)::Bool
-    return GetIndexWithKMP(string, sub_string, ignore_case) != NO_SUBSTRING_INDEX
+function contain_substring_with_kmp(string::String, sub_string::String, ignore_case::Bool)::Bool
+    return get_index_with_kmp(string, sub_string, ignore_case) != NO_SUBSTRING_INDEX
 end

--- a/test/sorts.jl
+++ b/test/sorts.jl
@@ -1,13 +1,13 @@
 @testset "Sorts" begin
     sorts = [
-        BubbleSort!,
-        BucketSort!,
-        CountingSort!,
-        ExchangeSort!,
-        InsertionSort!,
-        MergeSort!,
-        QuickSort!,
-        SelectionSort!,
+        bubble_sort!
+        bucket_sort!
+        counting_sort!
+        exchange_sort!
+        insertion_sort!
+        merge_sort!
+        quick_sort!
+        selection_sort!
     ]
 
     for f in sorts

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -31,29 +31,29 @@
         # contain sub string
         string = "seems like kmp search works"
         sub_string = "seems like kmp search"
-        @test ContainSubstringWithKMP(string, sub_string, false) == true
+        @test contain_substring_with_kmp(string, sub_string, false) == true
         string = "ABABDABACDABABCABAB"
         sub_string = "ABABCABAB"
-        @test ContainSubstringWithKMP(string, sub_string, false) == true
+        @test contain_substring_with_kmp(string, sub_string, false) == true
         string = "abcxabcdabcdabcy"
         sub_string = "abcdabcy"
-        @test ContainSubstringWithKMP(string, sub_string, false) == true
+        @test contain_substring_with_kmp(string, sub_string, false) == true
         # does not contain sub string
         string = "ABABDABACDABABCABAB"
         sub_string = "X"
-        @test ContainSubstringWithKMP(string, sub_string, false) == false
+        @test contain_substring_with_kmp(string, sub_string, false) == false
         string = "abcxabcdabcdabcy"
         sub_string = "so this"
-        @test ContainSubstringWithKMP(string, sub_string, false) == false
+        @test contain_substring_with_kmp(string, sub_string, false) == false
         # ignore cases
         string = "SeEms Like IgNOrE CaSe Work"
         sub_string = "seems like ignore case work"
-        @test ContainSubstringWithKMP(string, sub_string, true) == true
+        @test contain_substring_with_kmp(string, sub_string, true) == true
         string = "123 456 AbC"
         sub_string = "123 456 ABC"
-        @test ContainSubstringWithKMP(string, sub_string, true) == true
+        @test contain_substring_with_kmp(string, sub_string, true) == true
         string = "abcdefg"
         sub_string = "ABCDEFG"
-        @test ContainSubstringWithKMP(string, sub_string, true) == true
+        @test contain_substring_with_kmp(string, sub_string, true) == true
     end
 end


### PR DESCRIPTION
Hey sir, I had renamed the below came cased function to underscore
Note: *may be unnecessary but I think it would introduce a more consistent syntax style*
```
1. bubble_sort!
2. bucket_sort!
3. counting_sort!
4. exchange_sort!
5. insertion_sort!
6. merge_sort!
7. quick_sort!
8. selection_sort!
9. contain_substring_with_kmp
```