### PR TITLE
feat: Add Simpson's Integration algorithm

### DIFF
--- a/src/TheAlgorithms.jl
+++ b/src/TheAlgorithms.jl
@@ -69,6 +69,7 @@ export perfect_square
 export permutation
 export prime_check
 export prime_factors
+export simpsons_integration
 export sum_ap
 export sum_gp
 export surfarea_cube
@@ -171,6 +172,7 @@ include("math/permutation.jl")
 include("math/prime_check.jl")
 include("math/prime_factors.jl")
 include("math/sieve_of_eratosthenes.jl")
+include("math/simpsons_integration.jl")
 include("math/sum_of_arithmetic_series.jl")
 include("math/sum_of_geometric_progression.jl")
 include("math/verlet.jl")

--- a/src/math/simpsons_integration.jl
+++ b/src/math/simpsons_integration.jl
@@ -41,4 +41,3 @@ function simpsons_integration(f::Function, a::Real, b::Real, n::Int)
     # approximate integral of f
     return (Δₓ / 3) * Σ
 end
-

--- a/test/math.jl
+++ b/test/math.jl
@@ -246,8 +246,8 @@
     end
 
     @testset "Math: Simpson's Integration" begin
-        @test isapprox(simpsons_integration(x->3*x^2, 0, 1, 100000), 1, atol = 0.01)
-        @test isapprox(simpsons_integration(x->sin(x), 0, pi, 1000), 2, atol = 0.1)
+        @test isapprox(simpsons_integration(x -> 3*x^2, 0, 1, 100000), 1, atol = 0.01)
+        @test isapprox(simpsons_integration(x -> sin(x), 0, pi, 1000), 2, atol = 0.1)
         @test simpsons_integration(x -> 4 / (1 + x^2), 0, 1, 100_000) ≈ pi
     end
     
@@ -283,4 +283,3 @@
    end
 
 end
-


### PR DESCRIPTION
Hi. 

I add the Simpson's Sum Integration algorithm, along with other integration methods in other PR's. 
This version it's very fast, readable and zero allocation in memory. Which could be comproved using @btime macro.
Please evaluate my code so that it can be approved. 

thanks.