### PR TITLE
fix: wrong output order

### DIFF
--- a/src/project-rosalind/count_nucleotide.jl
+++ b/src/project-rosalind/count_nucleotide.jl
@@ -7,5 +7,5 @@ of length at most 1000 nt.
 Return: Four integers (separated by spaces) counting the respective number of times that the symbols 'A', 'C', 'G', and 'T' occur in s
 """
 function count_nucleotides(s::AbstractString)
-    return join(map(y -> count(x -> x == y, s), ['A', 'T', 'G', 'C']), " ")
+    return join(map(y -> count(x -> x == y, s), ['A', 'C', 'G', 'T']), " ")
 end

--- a/test/project-rosalind.jl
+++ b/test/project-rosalind.jl
@@ -2,7 +2,7 @@
     @testset "Project Rosalind: Count Nucleotides" begin
         @test count_nucleotides(
             "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC",
-        ) == "20 21 17 12"
+        ) == "20 12 17 21"
     end
 
     @testset "Project Rosalind: DNA to RNA" begin


### PR DESCRIPTION
Wrong output order in [count_nucleotide.jl](https://github.com/Nikola-Mircic/Julia/blob/main/src/project-rosalind/count_nucleotide.jl) on line 10.