### PR TITLE
Add Affine Cipher

### DIFF
--- a/src/TheAlgorithms.jl
+++ b/src/TheAlgorithms.jl
@@ -16,6 +16,7 @@ export Hanoi
 export caesar
 # export rotate
 export atbash_encode
+export affine
 
 # Exports: data_structures
 export AbstractBinarySearchTree_arr
@@ -185,6 +186,7 @@ include("basic/hanoi.jl")
 # Includes: cipher
 include("cipher/caesar.jl")
 include("cipher/atbash.jl")
+include("cipher/affine.jl")
 
 # Includes: data_structures
 include("data_structures/binary_heap.jl")

--- a/src/cipher/affine.jl
+++ b/src/cipher/affine.jl
@@ -57,4 +57,3 @@ function affine(text::String, alphabet::String, nMultiply::Int, nAdd::Int)
     ])
 
 end # function
-affine()

--- a/src/cipher/affine.jl
+++ b/src/cipher/affine.jl
@@ -1,0 +1,60 @@
+"""
+    affine(text, alphabet, nMultiply, nAdd)
+
+Program to implement affine cipher for the given input. A full description of it can be found on [wikipedia](https://en.wikipedia.org/wiki/Affine_cipher).
+
+# Arguments:
+- `text` : text to be encoded/decoded
+- `alphabet` : the alphaebt the text uses
+- `nMultiply` : the number to the multiply by (a)
+- `nAdd` : the number to add (b)
+
+# Examples/Tests
+```julia
+
+julia> affine("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz", 3, 1)
+"behknqtwzcfiloruxadgjmpsvy"
+
+julia> affine("whyhellothere", "abcdefghijklmnopqrstuvwxyz", 17, 82)
+"otwtujjiptuhu"
+
+julia> affine("1234", "0123456789", 5, 2)
+"9630"
+
+```
+
+# Algorithm:
+As usual, julia's 1 based indexing doesn't play nicely with the affine cipher, but all that is required is `-1` from the initial index of the letter and `+1` after the mod.  
+
+An affine cipher uses a simple function: `f(x) = ax + b`.
+
+Notes:
+
+- `nMultiply` and `length(alphabet)` *must* be coprime so that the two plaintext letters are not substituted for the same cipehrtext letter.
+- This doesn't check that the all of the characters in `text` actually are in `alphabet`, but that does need to be the case!
+
+```julia
+
+join([
+    alphabet[((findfirst(isequal(letter), alphabet) - 1) * nMultiply + nAdd) % length(alphabet) + 1]
+    for letter in text
+])
+
+```
+
+# References:
+https://www.dcode.fr/affine-cipher  
+https://github.com/Squalm/Cipher-Tools
+
+
+### Contributed by: [Chirp (Squalm)](https://github.com/Squalm)
+"""
+function affine(text::String, alphabet::String, nMultiply::Int, nAdd::Int)
+
+    return join([
+        alphabet[((findfirst(isequal(letter), alphabet) - 1) * nMultiply + nAdd) % length(alphabet) + 1]
+        for letter in text
+    ])
+
+end # function
+affine()

--- a/test/cipher.jl
+++ b/test/cipher.jl
@@ -29,12 +29,12 @@
         input = "secrets"
         a = 3
         b = 1
-        @test affine(input, alphabet, a, b) = "dnhangd"
+        @test affine(input, alphabet, a, b) == "dnhangd"
         alphabet = "0123456789"
         input = "1234"
         a = 7
         b = 2
-        @test affine(input, alphabet, a, b) = "9630"
+        @test affine(input, alphabet, a, b) == "9630"
     end
     end
 end

--- a/test/cipher.jl
+++ b/test/cipher.jl
@@ -23,5 +23,18 @@
         # rot = 0
         # s = "hello"
         # @test rotate(rot, s) == "hello"
+
+    @testset "Cipher: affine" begin
+        alphabet = "abcdefghijklmnopqrstuvwxyz"
+        input = "secrets"
+        a = 3
+        b = 1
+        @test affine(input, alphabet, a, b) = "dnhangd"
+        alphabet = "0123456789"
+        input = "1234"
+        a = 7
+        b = 2
+        @test affine(input, alphabet, a, b) = "9630"
+    end
     end
 end


### PR DESCRIPTION
First time contributing, sorry in advance!

I added an algorithm to encode using an affine cipher, which I essentially just pulled from an [ongoing project of mine](https://github.com/Squalm/Cipher-Tools). I mostly thought this would be relevant because atbash is (if I remember correctly) just a specific affine cipher, so hopefully it is! (and perhaps it would be worth making that clear in the code?)

I've run the tests manually but haven't actually run the tests file because I wasn't sure how to so I may have made a mistake there.