### PR TITLE
Added average absolute deviation

### DIFF
--- a/src/TheAlgorithms.jl
+++ b/src/TheAlgorithms.jl
@@ -78,6 +78,7 @@ export area_rhombus
 export area_square
 export area_trapezium
 export area_triangle
+export average_absolute_deviation
 export bab_sqrt
 export catalan
 export ceil_val
@@ -230,6 +231,7 @@ include("machine_learning/k_means.jl")
 include("math/abs.jl")
 include("math/area.jl")
 include("math/armstrong_number.jl")
+include("math/average_absolute_deviation.jl")
 include("math/average_mean.jl")
 include("math/average_median.jl")
 include("math/average_mode.jl")

--- a/src/math/average_absolute_deviation.jl
+++ b/src/math/average_absolute_deviation.jl
@@ -1,0 +1,25 @@
+"""
+    average_absolute_deviation(numbers)
+The average absolute deviation of a data set is the average of the absolute deviations from the mean.
+It is  a measure of statistical dispersion or variability.
+
+# Input parameters:
+- `numbers` : The numbers to find the average absolute deviation of.
+
+# Examples/Tests:
+```julia
+average_absolute_deviation([1, 2, 3, 4, 5])     # returns 1.2
+average_absolute_deviation([0])                 # returns 0.0
+average_absolute_deviation([5.5, 64.3, 100.4])  # returns 34.16
+```
+
+# Reference
+- https://mathworld.wolfram.com/AverageAbsoluteDeviation.html
+
+Contributed by [Praneeth Jain](https://www.github.com/PraneethJain)
+"""
+function average_absolute_deviation(numbers::Vector{T}) where {T<:Number}
+    len = length(numbers)
+    mean = sum(numbers) / len
+    return round(sum(abs(num - mean) for num in numbers) / len, digits = 2)
+end

--- a/test/math.jl
+++ b/test/math.jl
@@ -105,6 +105,12 @@
         @test is_armstrong(x) == false
     end
 
+    @testset "Math: Average Absolute Deviation" begin
+        @test average_absolute_deviation([1, 2, 3, 4, 5]) == 1.2
+        @test average_absolute_deviation([0]) == 0.0
+        @test average_absolute_deviation([5.5, 64.3, 100.4]) == 34.16
+    end
+
     @testset "Math: Average Mean" begin
         @test mean([3, 6, 9, 12, 15, 18, 21]) == 12.0
         @test mean([5, 10, 15, 20, 25, 30, 35]) == 20.0


### PR DESCRIPTION
The average absolute deviation of a data set is the average of the absolute deviations from the mean.
It is  a measure of statistical dispersion or variability.