### PR TITLE
tests: check if `area_heron_triangle` throws when input sides do not form a triangle

### DIFF
--- a/test/math.jl
+++ b/test/math.jl
@@ -59,6 +59,9 @@ using TheAlgorithms.Math
         @test_throws DomainError area_heron_triangle(-1, -2, 1)
         @test_throws DomainError area_heron_triangle(1, -2, 1)
         @test_throws DomainError area_heron_triangle(-1, 2, 1)
+        @test_throws DomainError area_heron_triangle(1, 1, 3)
+        @test_throws DomainError area_heron_triangle(1, 3, 1)
+        @test_throws DomainError area_heron_triangle(3, 1, 1)
 
         @test area_parallelogram(10, 20) == 200
         @test_throws DomainError area_parallelogram(-1, -2)


### PR DESCRIPTION
This line
https://github.com/TheAlgorithms/Julia/blob/40586f4c0fc11b9814b7aabef1b01e2975b332c0/src/math/area.jl#L160
is not covered by any on the existing tests. This PR adds missing tests.