### PR TITLE
chore: properly install `julia` in `.gitpod.dockerfile`

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,4 +1,9 @@
-FROM gitpod/workspace-full-vnc
+FROM gitpod/workspace-base:2023-10-04-18-52-46
 
-RUN sudo apt-get update \
-    && sudo apt-get install julia -y
+ENV JULIA_TMP="julia_tmp.tar.gz"
+
+RUN test ! -e "${JULIA_TMP}" \
+    && curl https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.3-linux-x86_64.tar.gz -sSf -o "${JULIA_TMP}" \
+    && tar zxvf ${JULIA_TMP} \
+    && rm ${JULIA_TMP} \
+    && echo "export PATH=${HOME}/julia-1.9.3/bin/:\$PATH" >> ~/.bashrc


### PR DESCRIPTION
The current [.gitpod.dockerfile](https://github.com/TheAlgorithms/Julia/blob/1ba04f5c3984da98eb0d0a151f729e6445c6488b/.gitpod.dockerfile) does not work.

I decided to use the `workspace-base` instead of `workspace-full-vnc`.