### PR TITLE
style: use int as the return type

### DIFF
--- a/src/searches/binary_search.jl
+++ b/src/searches/binary_search.jl
@@ -67,15 +67,14 @@ function binary_search(
 ) where {T<:Real}
     if (r >= l)
         mid = Int(ceil(l + (r - l) / 2))
-        # println(mid)
         if (arr[mid] == x)
-            return "Element present at index $mid"
+            return mid
         elseif (arr[mid] > x)
             binary_search(arr, l, mid - 1, x)
         else
             binary_search(arr, mid + 1, r, x)
         end
     else
-        return "Element not present in array"
+        return -1
     end
 end

--- a/src/searches/exponential_search.jl
+++ b/src/searches/exponential_search.jl
@@ -19,7 +19,7 @@ Contributed By:- [Ash](https://github.com/ashwani-rathee)
 function exponential_search(arr::AbstractArray{T,1}, x::T) where {T<:Real}
     n = size(arr)[1]
     if (arr[1] == x)
-        return "Element present at index 1"
+        return 1
     end
 
     i = 1

--- a/test/searches.jl
+++ b/test/searches.jl
@@ -16,8 +16,10 @@ using TheAlgorithms.Searches
             # Second method used for exponential search
             arr = [1, 2, 3, 4, 13, 15, 20]
             # The next three values used are the result of the while-loop inside `exponential search`
-            @test binary_search(arr, 4, 7, 4) == "Element present at index 4"
-            @test binary_search(arr, 4, 7, 10) == "Element not present in array"
+            @test binary_search(arr, 4, 7, 4) == 4
+            @test binary_search(arr, 4, 7, 20) == 7
+            @test binary_search(arr, 4, 7, 10) == -1
+            @test binary_search(arr, 4, 7, 21) == -1
         end
     end
 
@@ -30,13 +32,11 @@ using TheAlgorithms.Searches
 
     @testset "Searches: Exponential" begin
         arr = [1, 2, 3, 4, 13, 15, 20]
-        x = 4
-        n = size(arr)[1]
-        l = 1
-        r = n
-        @test exponential_search(arr, 1) == "Element present at index 1"
-        @test exponential_search(arr, x) == "Element present at index 4"
-        @test exponential_search(arr, 100) == "Element not present in array"
+        @test exponential_search(arr, 1) == 1
+        @test exponential_search(arr, 4) == 4
+        @test exponential_search(arr, 20) == 7
+        @test exponential_search(arr, 5) == -1
+        @test exponential_search(arr, 100) == -1
     end
 
     @testset "Searches: Interpolation" begin


### PR DESCRIPTION
I think it makes more sense to use `int` as a return type of [`binary_search`](https://github.com/TheAlgorithms/Julia/blob/c865d384273f4f09a8581948553d16389593a935/src/searches/binary_search.jl#L62) and [`exponential_search`](https://github.com/TheAlgorithms/Julia/blob/c865d384273f4f09a8581948553d16389593a935/src/searches/exponential_search.jl#L19).