### PR TITLE
tests: add missing test cases for `caesar`

### DIFF
--- a/test/cipher.jl
+++ b/test/cipher.jl
@@ -10,10 +10,15 @@ using TheAlgorithms.Cipher
     end
 
     @testset "Cipher: caesar" begin
-        input = "stealth"
-        @test caesar(0, input) == "stealth"
-        input = "ghsozhv"
-        @test caesar(90, input) == "stealth"
+        @test caesar(0, "stealth") == "stealth"
+        @test caesar(90, "ghsozhv") == "stealth"
+
+        @test caesar(1, "ABC") == "BCD"
+        @test caesar(-1, "BCD") == "ABC"
+
+        @test caesar(2, "f(x)") == "h(z)"
+
+        @test caesar(5, 'a') == 'f'
 
         # rot = 13
         # s = "abcdefghijklmnopqrstuvwxyz"


### PR DESCRIPTION
This PR adds missing test cases for the function [`caesar`](https://github.com/TheAlgorithms/Julia/blob/8e3c9615dde24a960112d82b95cc96beaf15be9c/src/cipher/caesar.jl#L46).