### PR TITLE
refactor: make `dfs` return vector

### DIFF
--- a/src/graph/dfs.jl
+++ b/src/graph/dfs.jl
@@ -23,7 +23,13 @@ dfs(graph, 6)
 
 # output
 
-6 5 2 4 3 1
+6-element Vector{Int64}:
+ 6
+ 5
+ 2
+ 4
+ 3
+ 1
 ```
 
 Contributed by: [Yannick Brenning](https://github.com/ybrenning)
@@ -31,6 +37,7 @@ Contributed by: [Yannick Brenning](https://github.com/ybrenning)
 function dfs(graph::Vector{Vector{Int}}, source::Int = 1)
     # Use a boolean "visited" array to avoid processing a vertex more than once
     visited = [false for _ in 1:length(graph)]
+    result = Vector{Int}()
 
     stack = Stack{Int}()
     push!(stack, source)
@@ -39,7 +46,7 @@ function dfs(graph::Vector{Vector{Int}}, source::Int = 1)
 
     while length(stack) > 0
         curr_v = pop!(stack)
-        print(curr_v, " ")
+        push!(result, curr_v)
 
         # Add every unvisited target to the top of the stack
         for i in 1:length(graph[curr_v])
@@ -49,6 +56,5 @@ function dfs(graph::Vector{Vector{Int}}, source::Int = 1)
             end
         end
     end
-
-    return print("\n")
+    return result
 end

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -41,4 +41,18 @@ using TheAlgorithms.Graph
 
         @test_throws ErrorException bellman_ford(negative_edge_cycle, 1)
     end
+
+    @testset "dfs" begin
+        graph = [
+            [2, 3, 6],
+            [3, 4],
+            [4],
+            [1, 2, 5],
+            [2],
+            [1, 5]
+        ]
+
+        @test dfs(graph, 6) == [6, 5, 2, 4, 3, 1]
+        @test dfs(graph) == [1, 6, 5, 3, 4, 2]
+    end
 end


### PR DESCRIPTION
Current implementation of [`dfs`](https://github.com/TheAlgorithms/Julia/blob/ede895a5e5e194cf09b184de08313c599463ad84/src/graph/dfs.jl#L31) is not really testable: it displays the nodes. This PR changes that and adds missing tests.