### PR TITLE
refactor: make `bfs` return vector

### DIFF
--- a/src/graph/bfs.jl
+++ b/src/graph/bfs.jl
@@ -23,7 +23,13 @@ TheAlgorithms.Graph.bfs(graph, 4)
 
 # output
 
-4 1 2 5 3 6
+6-element Vector{Int64}:
+ 4
+ 1
+ 2
+ 5
+ 3
+ 6
 ```
 
 Contributed by: [Yannick Brenning](https://github.com/ybrenning)
@@ -31,6 +37,7 @@ Contributed by: [Yannick Brenning](https://github.com/ybrenning)
 function bfs(graph::Vector{Vector{Int}}, source::Int = 1)
     # Use a boolean "visited" array to avoid processing a vertex more than once
     visited = [false for _ in 1:length(graph)]
+    result = Vector{Int}()
 
     queue = Queue{Int}()
     enqueue!(queue, source)
@@ -39,7 +46,7 @@ function bfs(graph::Vector{Vector{Int}}, source::Int = 1)
 
     while length(queue) > 0
         curr_v = dequeue!(queue)
-        print(curr_v, " ")
+        push!(result, curr_v)
 
         # Add every unvisited target to the end of the queue
         for i in 1:length(graph[curr_v])
@@ -50,5 +57,5 @@ function bfs(graph::Vector{Vector{Int}}, source::Int = 1)
         end
     end
 
-    return print("\n")
+    return result
 end

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -41,4 +41,18 @@ using TheAlgorithms.Graph
 
         @test_throws ErrorException bellman_ford(negative_edge_cycle, 1)
     end
+
+    @testset "bfs" begin
+        graph = [
+            [2, 3, 6],
+            [3, 4],
+            [4],
+            [1, 2, 5],
+            [2],
+            [1, 5]
+        ]
+
+        @test bfs(graph, 4) == [4, 1, 2, 5, 3, 6]
+        @test bfs(graph) == [1, 2, 3, 6, 4, 5]
+    end
 end


### PR DESCRIPTION
Same as #201 but for [`bfs`](https://github.com/TheAlgorithms/Julia/blob/ede895a5e5e194cf09b184de08313c599463ad84/src/graph/bfs.jl#L31).