### PR TITLE
fix: make `determinant` throw

### DIFF
--- a/src/matrix/determinant.jl
+++ b/src/matrix/determinant.jl
@@ -16,7 +16,7 @@ Determinant of triangualar matrices is the product of their diagonal entries. He
 function determinant(mat)
     n, m = size(mat)
     if n != m
-        DomainError(mat, "The matrix should be a square matrix.")
+        throw(DomainError(mat, "The matrix should be a square matrix."))
     end
     L, U = lu_decompose(mat)
     l_prod = prod([L[i, i] for i in 1:n])

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -9,6 +9,9 @@ using TheAlgorithms.MatrixAlgo
         @test determinant(M1) == det(M1)
         @test round(determinant(M2), digits = 4) == round(det(M2), digits = 4)
         @test round(determinant(M3), digits = 4) == round(det(M3), digits = 4)
+
+        @test_throws DomainError determinant([1 2])
+        @test_throws DomainError determinant([1 2; 3 4; 5 6])
     end
 
     @testset "Matrix: LU Decompose" begin


### PR DESCRIPTION
The [`determinant`](https://github.com/TheAlgorithms/Julia/blob/ede895a5e5e194cf09b184de08313c599463ad84/src/matrix/determinant.jl#L16) function actually [does not throw](https://github.com/TheAlgorithms/Julia/blob/ede895a5e5e194cf09b184de08313c599463ad84/src/matrix/determinant.jl#L19) for _non-square_ inputs. This PR fixes that and adds missing test cases.