### PR TITLE
Enhancements to "Longest Increasing Subsequence"

### DIFF
--- a/src/longest_increasing_subsequence/binary_search.jl
+++ b/src/longest_increasing_subsequence/binary_search.jl
@@ -48,12 +48,10 @@ function lis(arr::Array{Int}, ::Val{:bs})
     last_pos = lis_len
     for i in len:-1:1
         if p[i] == last_pos
-            push!(lis_arr, arr[i])
+            pushfirst!(lis_arr, arr[i])
             last_pos -= 1
         end
     end
-
-    reverse!(lis_arr)
 
     return lis_arr
 end

--- a/src/longest_increasing_subsequence/binary_search.jl
+++ b/src/longest_increasing_subsequence/binary_search.jl
@@ -1,5 +1,5 @@
 """
-    lis(arr::Array{Int}, ::Val{:bs})
+    lis(arr::Array{<:Integer}, ::Val{:bs})
 
 # Arguments:
 - `arr`: sequence of integers
@@ -23,12 +23,12 @@ https://cp-algorithms.com/sequences/longest_increasing_subsequence.html
 - [Igor Malheiros](https://github.com/igormalheiros)
 """
 
-function lis(arr::Array{Int}, ::Val{:bs})
+function lis(arr::Array{T}, ::Val{:bs}) where T <: Integer
     len = length(arr)
-    memo = ones(Int, len)
+    memo = ones(T, len)
     p = ones(Int, len)
 
-    lis_arr = Int[]
+    lis_arr = T[]
 
     len == 0 && return lis_arr # if `arr` is empty
 

--- a/src/longest_increasing_subsequence/dynamic_programming.jl
+++ b/src/longest_increasing_subsequence/dynamic_programming.jl
@@ -1,5 +1,5 @@
 """
-    lis(arr::Array{Int}, ::Val{:dp})
+    lis(arr::Array{<:Integer}, ::Val{:dp})
 
 # Arguments:
 - `arr`: sequence of integers
@@ -23,12 +23,12 @@ https://cp-algorithms.com/sequences/longest_increasing_subsequence.html
 - [Igor Malheiros](https://github.com/igormalheiros)
 """
 
-function lis(arr::Array{Int}, ::Val{:dp})
+function lis(arr::Array{T}, ::Val{:dp}) where T <: Integer
     len = length(arr)
     memo = ones(Int, len)
     p = zeros(Int, len)
 
-    lis_arr = Int[]
+    lis_arr = T[]
 
     len == 0 && return lis_arr # if arr is empty
 

--- a/src/longest_increasing_subsequence/dynamic_programming.jl
+++ b/src/longest_increasing_subsequence/dynamic_programming.jl
@@ -51,11 +51,9 @@ function lis(arr::Array{Int}, ::Val{:dp})
 
     # Restoring
     while lis_pos != 0
-        push!(lis_arr, arr[lis_pos])
+        pushfirst!(lis_arr, arr[lis_pos])
         lis_pos = p[lis_pos]
     end
-
-    reverse!(lis_arr)
 
     return lis_arr
 end

--- a/test/longest_increasing_subsequence.jl
+++ b/test/longest_increasing_subsequence.jl
@@ -19,6 +19,12 @@ using TheAlgorithms.LongSubSeq
         # two possible results:
         @test lis([3, 4, -1, 5, 8, 2, 3, 12, 7, 9, 10], Val(:dp)) in
               [[-1, 2, 3, 7, 9, 10], [3, 4, 5, 8, 9, 10]]
+        # Boolean array
+        @test lis([true, false, false, true], Val(:dp)) == [false, true]
+        # other Integer subtypes
+        for T in [UInt128, UInt16, UInt32, UInt64, UInt8, BigInt, Int128, Int16, Int32, Int64, Int8]
+            @test lis(T[3, 10, 2, 1, 20], Val(:dp)) == T[3, 10, 20]
+        end
     end
 
     @testset "LIS: Binary Search approach!" begin
@@ -39,5 +45,11 @@ using TheAlgorithms.LongSubSeq
         # two possible results:
         @test lis([3, 4, -1, 5, 8, 2, 3, 12, 7, 9, 10], Val(:bs)) in
               [[-1, 2, 3, 7, 9, 10], [3, 4, 5, 8, 9, 10]]
+        # Boolean array
+        @test lis([true, false, false, true], Val(:bs)) == [false, true]
+        # other Integer subtypes
+        for T in [UInt128, UInt16, UInt32, UInt64, UInt8, BigInt, Int128, Int16, Int32, Int64, Int8]
+            @test lis(T[3, 10, 2, 1, 20], Val(:bs)) == T[3, 10, 20]
+        end
     end
 end


### PR DESCRIPTION
**Performance improvement**: Use `pushfirst!` directly when creating the result `lis_arr` instead of unnecessarily doing `push!` in a loop and then `reverse!` later

**More Julian code**: Writing generic code is strongly encouraged in Julia, and it's more in line with Julian convention to accept an array of any `Integer` subtype, instead of artificially limiting it to `Int` only.  Since `where T <: Integer` is pretty intuitive and easy to make sense of, it doesn't particularly affect readability. And this makes it clearer which of the arrays used in the function are meant to hold values from the original array (those typed `T`) and which are meant to hold indices (those typed `Int`), which can make it easier to understand the algorithms. 
