### PR TITLE
Binary Length Improvements

### DIFF
--- a/src/math/Math.jl
+++ b/src/math/Math.jl
@@ -26,6 +26,9 @@ export area_trapezium
 export area_triangle
 export average_absolute_deviation
 export bab_sqrt
+export bin_length
+export bin_length_long
+export bin_length_short
 export catalan
 export ceil
 export collatz_sequence
@@ -89,6 +92,7 @@ include("average_mean.jl")
 include("average_median.jl")
 include("average_mode.jl")
 include("babylonian_sqrt.jl")
+include("binary_length.jl")
 include("catalan_number.jl")
 include("ceil.jl") # needed by average_median
 include("collatz_sequence.jl")

--- a/src/math/binary_length.jl
+++ b/src/math/binary_length.jl
@@ -22,7 +22,7 @@ Contributed by: [Praneeth Jain](https://www.github.com/PraneethJain)
 """
 function bin_length(binNum::T) where {T<:Integer}
     binNum <= 0 && throw(DomainError("binNum must be a positive integer"))
-    return floor(Int, log2(binNum)) + 1
+    return floor(log2(binNum)) + 1
 end
 
 """
@@ -58,6 +58,8 @@ doubled amount.
 Contributed by F35H: https://github.com/F35H
 """
 function bin_length_long(binNum::T) where {T<:Integer}
+    binNum <= 0 && throw(DomainError("binNum must be a positive integer"))
+
     finNum = 0
     seq = 1
 
@@ -101,6 +103,8 @@ Contributors:
 - [F45H](https://github.com/F35H)
 """
 function bin_length_short(binNum::T) where {T<:Integer}
+    binNum <= 0 && throw(DomainError("binNum must be a positive integer"))
+
     finNum = 0
     i = 1
 

--- a/src/math/binary_length.jl
+++ b/src/math/binary_length.jl
@@ -1,19 +1,3 @@
-function bin_length_long(s::AbstractString)
-    binNum = parse(UInt, s)
-
-    finNum = 0
-    seq = 1
-
-    for i in 1:binNum
-        if (i == seq)
-            finNum += 1
-            seq *= 2
-        end
-    end
-
-    return string(finNum)
-end
-
 """
 This algorithm features use of the OEIS entry A070939 - 
 length of Binary Representation of n. It finds 
@@ -46,19 +30,18 @@ doubled amount.
 #Contributions:
 Contributed by F35H: https://github.com/F35H
 """
-
-function bin_length_short(s::AbstractString)
-    binNum = parse(UInt, s)
-
+function bin_length_long(binNum::T) where {T<:Unsigned}
     finNum = 0
-    i = 1
+    seq = 1
 
-    while i <= binNum
-        i *= 2
-        finNum += 1
+    for i in 1:binNum
+        if (i == seq)
+            finNum += 1
+            seq *= 2
+        end
     end
 
-    return string(finNum)
+    return finNum
 end
 
 """
@@ -68,7 +51,7 @@ the length of any binary number and returns said length.
   
  https://oeis.org/A070939
 
-This function, as believed, is O(n)
+This function, as believed, is O(log(n))
 
 The idea follows that the sequence is dependent on 
 a repeating pattern of 2. The final number being finNum
@@ -90,3 +73,14 @@ final number that iterates on every doubling of i.
 Contributors:
 - [F45H](https://github.com/F35H)
 """
+function bin_length_short(binNum::T) where {T<:Unsigned}
+    finNum = 0
+    i = 1
+
+    while i <= binNum
+        i *= 2
+        finNum += 1
+    end
+
+    return finNum
+end

--- a/src/math/binary_length.jl
+++ b/src/math/binary_length.jl
@@ -1,4 +1,31 @@
 """
+    bin_length(binNum)
+Returns the length of binNum's binary representation.
+
+# Input parameters:
+- `binNum` : The number to find the binary length of.
+
+# Examples/Tests:
+```julia
+bin_length(1)       # returns 1
+bin_length(2)       # returns 2
+bin_length(3)       # returns 2
+bin_length(4)       # returns 3
+bin_length(5)       # returns 3
+bin_length(12)      # returns 4
+bin_length(256)     # returns 9
+bin_length(1024)    # returns 11
+bin_length(-1)      # throws DomainError
+```
+
+Contributed by: [Praneeth Jain](https://www.github.com/PraneethJain)
+"""
+function bin_length(binNum::T) where {T<:Integer}
+    binNum <= 0 && throw(DomainError("binNum must be a positive integer"))
+    return floor(Int, log2(binNum)) + 1
+end
+
+"""
 This algorithm features use of the OEIS entry A070939 - 
 length of Binary Representation of n. It finds 
 the length of any binary number and returns said length.
@@ -30,7 +57,7 @@ doubled amount.
 #Contributions:
 Contributed by F35H: https://github.com/F35H
 """
-function bin_length_long(binNum::T) where {T<:Unsigned}
+function bin_length_long(binNum::T) where {T<:Integer}
     finNum = 0
     seq = 1
 
@@ -73,7 +100,7 @@ final number that iterates on every doubling of i.
 Contributors:
 - [F45H](https://github.com/F35H)
 """
-function bin_length_short(binNum::T) where {T<:Unsigned}
+function bin_length_short(binNum::T) where {T<:Integer}
     finNum = 0
     i = 1
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -142,6 +142,20 @@ using TheAlgorithms.Math
         @test median([0]) == 0
     end
 
+    @testset "Math: Binary Length" begin
+        for bin_length_func in [bin_length, bin_length_long, bin_length_short]
+            @test bin_length_func(1) == 1
+            @test bin_length_func(2) == 2
+            @test bin_length_func(3) == 2
+            @test bin_length_func(4) == 3
+            @test bin_length_func(5) == 3
+            @test bin_length_func(12) == 4
+            @test bin_length_func(256) == 9
+            @test bin_length_func(1024) == 11
+            @test_throws DomainError bin_length_func(-1)
+        end
+    end
+
     @testset "Math: Catalan Number" begin
         @test catalan(0) == 1
         @test catalan(3) == 5


### PR DESCRIPTION
#207 
- Moved binary_length.jl from the string folder to the math folder.
- Fix incorrect time complexity in the function documentation.
- Added a faster implementation of bin_length.
- Added tests for all the bin_length functions.