### PR TITLE
tests: test `weight_conversion` with non existing units

### DIFF
--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -124,6 +124,8 @@ using TheAlgorithms.Conversions
               1.660540199e-23
         @test weight_conversion("atomic-mass-unit", "atomic-mass-unit", 2) ==
               1.999999998903455
+        @test_throws ErrorException weight_conversion("kg", "wrong_unit", 1)
+        @test_throws ErrorException weight_conversion("wrong_unit", "kg", 1)
     end
 
     @testset "Conversions: Temparature Conversions" begin


### PR DESCRIPTION
This PR adds a test _covering_ this line:
https://github.com/TheAlgorithms/Julia/blob/fa5dd9c754d057e5ba7ce307e7962d8f8ead0fef/src/conversions/weight_conversion.jl#L29
