### PR TITLE
tests: test `length_conversion` with non existing units

### DIFF
--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -180,5 +180,7 @@ using TheAlgorithms.Conversions
         @test length_conversion(5, "in", "m") ≈ 0.127
         @test length_conversion(3, "ft", "mm") ≈ 914.4
         @test length_conversion(10, "mi", "km") ≈ 16.0934
+        @test_throws ErrorException length_conversion(1, "m", "wrong_unit")
+        @test_throws ErrorException length_conversion(1, "wrong_unit", "m")
     end
 end


### PR DESCRIPTION
This PR adds a test covering this line:
https://github.com/TheAlgorithms/Julia/blob/2dc61a838612c19783730abdc25c104cac3ccf2c/src/conversions/length_conversion.jl#L69

It is similar to #220.